### PR TITLE
upgrade pg to 9.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     - ./program.sh:/tmp/program.sh
      
   database:
-    image: postgres:9.3
+    image: postgres:9.4
     container_name: postgres_database
 
   conjur:


### PR DESCRIPTION
Handle the conjur-quickstart PS upgrade to 9.4.
It is a prerequisite for the audit atomicity.
New data type JsonB was introduced in PS9.4 and is used by the audit. 