### PR TITLE
Added a fix for the updated PG 9.4 container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
   database:
     image: postgres:9.4
     container_name: postgres_database
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   conjur:
     image: cyberark/conjur


### PR DESCRIPTION
Postgres introduced a change that you can't start a pg container
without setting a password. They also introduced a new flag named
`POSTGRES_HOST_AUTH_METHOD` that you can set to trust in order to
let anyone connect with the db without a password (as we do today).
This is ok for our ci and dev envs so this commit adds this env var
to all pg containers that didn't have a password set for them.

Connected to #10 