### PR TITLE
Update docker-compose.yml to handle authenticators

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres@database/postgres
       CONJUR_DATA_KEY:
+      CONJUR_AUTHENTICATORS:
     depends_on:
     - database
     restart: on-failure


### PR DESCRIPTION
Ensure that CONJUR_AUTHENTICATORS environment variable is passed to the conjur container.
This is required to handle multiple authenticators when using docker.

Signed-off-by: Jaroslaw Szczegielniak <szjarek@outlook.com>

### What does this PR do?
Please read above.
Main tests that come to mind:
* [docker-compose up] starts all containers without errors.
* Starting containers using [docker-compose up] after CONJUR_AUTHENTICATORS environment variable value is set causes this value to be available within the conjur_server container.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation