### PR TITLE
Generate nginx certificate using cyberark/conjur openssl tool

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   openssl:
-    image: svagi/openssl:latest
+    image: cyberark/conjur
     container_name: openssl
     entrypoint:
      - openssl
@@ -13,13 +13,13 @@ services:
      - -nodes
      - -x509
      - -config
-     - tmp/conf/tls.conf
+     - /tmp/conf/tls.conf
      - -extensions
      - v3_ca
      - -keyout
-     - tmp/conf/nginx.key
+     - /tmp/conf/nginx.key
      - -out
-     - tmp/conf/nginx.crt
+     - /tmp/conf/nginx.crt
     volumes:
      - ./conf/tls/:/tmp/conf
   


### PR DESCRIPTION
### What does this PR do?

Today quickstart suite is using [frapsoft/openssl](https://hub.docker.com/r/frapsoft/openssl) container image for generating nginx self-signed certificate.
The image has been not updated for 4 years.
This PR removes dependency by `frapsoft/openssl` image and uses `cyberark/conjur` container's openssl tool in order to generate nginx self-signed certificate.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation