### PR TITLE
Use Conjur CLI v8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+
+# Changes to .trivyignore require Security Architect approval
+.trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
+# Changes to .codeclimate.yml require Quality Architect approval
+.codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects
+
+# Changes to SECURITY.md require Security Architect approval
+SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 my_app_data
 data_key
 admin_data
+my_api_keys
 conf/tls/nginx.*

--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ admin user.
    additional initcommand is issued, the Conjur client and the Conjur server
    remain connected.
 
-   Use the account name that you created in step 5:
+   Use the account name that you created in step 5. You will be prompted to trust
+   the TLS certificate of the Conjur server. Type `y` to trust the certificate:
    ```
-   docker-compose exec client conjur init -u conjur -a myConjurAccount
+   docker-compose exec client conjur init -u https://proxy -a myConjurAccount --self-signed
    ```
 
    **Verification**
@@ -187,7 +188,7 @@ user that represents your application, and a variable.
    Log in to Conjur as admin. When prompted for a password, insert the API key
    stored in the `admin_data` file:
    ```
-   docker-compose exec client conjur authn login -u admin
+   docker-compose exec client conjur login -u admin
    ```
 
    **Verification**
@@ -201,7 +202,7 @@ user that represents your application, and a variable.
    Load the provided sample policy into Conjur built-in `root` policy to create
    the resources for the BotApp:
    ```
-   docker-compose exec client conjur policy load root policy/BotApp.yml > my_app_data
+   docker-compose exec client conjur policy load -b root -f policy/BotApp.yml > my_app_data
    ```
 
    Conjur generates the following API keys and stores them in a file, my_app_data:
@@ -222,7 +223,7 @@ user that represents your application, and a variable.
 
    Log out of Conjur:
    ```
-   docker-compose exec client conjur authn logout
+   docker-compose exec client conjur logout
    ```
 
    **Verification**
@@ -240,13 +241,13 @@ In this unit you will learn how to store your first secret in Conjur.
    Log in as Dave, the human user. When prompted for a password, copy and paste
    Dave’s API key stored in the `my_app_data` file:
    ```
-   docker-compose exec client conjur authn login -u Dave@BotApp
+   docker-compose exec client conjur login -u Dave@BotApp
    ```
 
    **Verification**
    To verify that you logged in successfully, run:
    ```
-   docker-compose exec client conjur authn whoami
+   docker-compose exec client conjur whoami
    ```
 
    The terminal returns:
@@ -267,7 +268,7 @@ In this unit you will learn how to store your first secret in Conjur.
 
    Store the generated value in Conjur:
    ```
-   docker-compose exec client conjur variable values add BotApp/secretVar ${secretVal}
+   docker-compose exec client conjur variable set -i BotApp/secretVar -v ${secretVal}
    ```
 
    A policy predefined variable named `BotApp/secretVar` is set with a random
@@ -446,14 +447,14 @@ state, you can restart your environment as follows:
    example:
 
    ```
-   docker-compose exec client conjur init -u conjur -a myConjurAccount
+   docker-compose exec client conjur init -u https://proxy -a myConjurAccount --self-signed
    ```
 
 1. Log in again to Conjur as admin. When prompted for a password, insert the
    API key stored in the `admin_data` file:
 
    ```
-   docker-compose exec client conjur authn login -u admin
+   docker-compose exec client conjur login -u admin
    ```
 
    **Verification**
@@ -561,7 +562,7 @@ Then try the following:
    And log in again, e.g.:
 
    ```
-   docker-compose exec client conjur authn login -u admin
+   docker-compose exec client conjur login -u admin
    ```
 
 1. If "A server is already running" does not show in the Conjur container
@@ -575,7 +576,7 @@ Then try the following:
    and try logging in again, e.g.:
 
    ```
-   docker-compose exec client conjur authn login -u admin
+   docker-compose exec client conjur login -u admin
    ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ user that represents your application, and a variable.
    Log in to Conjur as admin. When prompted for a password, insert the API key
    stored in the `admin_data` file:
    ```
-   docker-compose exec client conjur login -u admin
+   docker-compose exec client conjur login -i admin
    ```
 
    **Verification**
@@ -241,7 +241,7 @@ In this unit you will learn how to store your first secret in Conjur.
    Log in as Dave, the human user. When prompted for a password, copy and paste
    Dave’s API key stored in the `my_app_data` file:
    ```
-   docker-compose exec client conjur login -u Dave@BotApp
+   docker-compose exec client conjur login -i Dave@BotApp
    ```
 
    **Verification**
@@ -454,7 +454,7 @@ state, you can restart your environment as follows:
    API key stored in the `admin_data` file:
 
    ```
-   docker-compose exec client conjur login -u admin
+   docker-compose exec client conjur login -i admin
    ```
 
    **Verification**
@@ -562,7 +562,7 @@ Then try the following:
    And log in again, e.g.:
 
    ```
-   docker-compose exec client conjur login -u admin
+   docker-compose exec client conjur login -i admin
    ```
 
 1. If "A server is already running" does not show in the Conjur container
@@ -576,7 +576,7 @@ Then try the following:
    and try logging in again, e.g.:
 
    ```
-   docker-compose exec client conjur login -u admin
+   docker-compose exec client conjur login -i admin
    ```
 
 ## Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     restart: on-failure
 
   client:
-    image: cyberark/conjur-cli:5
+    image: cyberark/conjur-cli:8
     container_name: conjur_client
     depends_on: [ proxy ]
     entrypoint: sleep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
     image: postgres:10.16
     container_name: postgres_database
     environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_HOST_AUTH_METHOD: password
+      POSTGRES_PASSWORD: SuperSecretPg
     ports:
       - 8432:5432
 
@@ -54,7 +55,7 @@ services:
     container_name: conjur_server
     command: server
     environment:
-      DATABASE_URL: postgres://postgres@database/postgres
+      DATABASE_URL: postgres://postgres:SuperSecretPg@database/postgres
       CONJUR_DATA_KEY:
       CONJUR_AUTHENTICATORS:
     depends_on:

--- a/test_workflow.sh
+++ b/test_workflow.sh
@@ -88,7 +88,7 @@ announce "UNIT 3. Store a Secret in Conjur"
 echo "Step 1: Log in as Dave"
 cat my_app_data | awk '/"api_key":/{print $NF}' | tr -d '"' > my_api_keys
 dave_api_key="$(cat my_api_keys | awk 'NR==2')"
-docker-compose exec -T client conjur login -u Dave@BotApp -p ${dave_api_key}
+docker-compose exec -T client conjur login -i Dave@BotApp -p ${dave_api_key}
 echo
 
 echo "Step 2: Generate Secret"

--- a/test_workflow.sh
+++ b/test_workflow.sh
@@ -64,30 +64,31 @@ docker-compose exec -T conjur conjurctl account create myConjurAccount > admin_d
 echo
 
 echo "Step 6: Connect the Conjur client to the Conjur server"
-docker container exec conjur_client conjur init -u conjur -a myConjurAccount
+# `echo "Y"` is used to accept the self-signed certificate
+echo "Y" | docker container exec -i conjur_client conjur init -u https://proxy -a myConjurAccount --self-signed
 echo
 
 announce "UNIT 2. Define Policy"
 
 echo "Step 1: Log in to Conjur as admin"
 admin_api_key="$(cat admin_data | awk '/API key for admin/{print $NF}' | tr -d '\r')"
-docker-compose exec -T client conjur authn login -u admin -p ${admin_api_key}
+docker-compose exec -T client conjur login -u admin -p ${admin_api_key}
 echo
 
 echo "Step 2: Load the Sample Policy"
-docker-compose exec -T client conjur policy load root policy/BotApp.yml > my_app_data
+docker-compose exec -T client conjur policy load -b root -f policy/BotApp.yml > my_app_data
 echo
 
 echo "Step 3: Log out of Conjur as admin"
-docker-compose exec -T client conjur authn logout
+docker-compose exec -T client conjur logout
 echo
 
 announce "UNIT 3. Store a Secret in Conjur"
 
 echo "Step 1: Log in as Dave"
 cat my_app_data | awk '/"api_key":/{print $NF}' | tr -d '"' > my_api_keys
-dave_api_key="$(cat my_api_keys | awk 'NR==1')"
-docker-compose exec -T client conjur authn login -u Dave@BotApp -p ${dave_api_key}
+dave_api_key="$(cat my_api_keys | awk 'NR==2')"
+docker-compose exec -T client conjur login -u Dave@BotApp -p ${dave_api_key}
 echo
 
 echo "Step 2: Generate Secret"
@@ -95,13 +96,13 @@ secretVal=$(openssl rand -hex 12 | tr -d '\r\n')
 echo
 
 echo "Step 3: Store Secret"
-docker-compose exec -T client conjur variable values add BotApp/secretVar ${secretVal}
+docker-compose exec -T client conjur variable set -i BotApp/secretVar -v ${secretVal}
 echo
 
 announce "UNIT 4. Run the Demo App"
 
 echo "Step 2: Generate Conjur Token in Bot App"
-bot_api_key="$(cat my_api_keys | awk 'NR==2' | tr -d '\r')"
+bot_api_key="$(cat my_api_keys | awk 'NR==1' | tr -d '\r')"
 docker-compose exec -T bot_app bash -c "curl -d "${bot_api_key}" -k https://proxy/authn/myConjurAccount/host%2FBotApp%2FmyDemoApp/authenticate > /tmp/conjur_token"
 echo
 

--- a/test_workflow.sh
+++ b/test_workflow.sh
@@ -72,7 +72,7 @@ announce "UNIT 2. Define Policy"
 
 echo "Step 1: Log in to Conjur as admin"
 admin_api_key="$(cat admin_data | awk '/API key for admin/{print $NF}' | tr -d '\r')"
-docker-compose exec -T client conjur login -u admin -p ${admin_api_key}
+docker-compose exec -T client conjur login -i admin -p ${admin_api_key}
 echo
 
 echo "Step 2: Load the Sample Policy"


### PR DESCRIPTION
### Desired Outcome

Use newly [released](https://github.com/cyberark/conjur-cli-go/releases/tag/v8.0.0) Golang CLI for Conjur.

### Implemented Changes

- Updates docker-compose.yml file to point to CLI version 8
- Updates CLI command syntax
- Use https proxy, allowing self-signed certs
- Fix test_workflow script bug in Units 3-4
- Use password with Postgres. Fixes #20 
- Add CODEOWNERS file so the @cyberark/community-and-integrations-team will be notified of issues

### Connected Issue/Story

CyberArk internal issue ID: ONYX-29538