### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: password
       POSTGRES_PASSWORD: SuperSecretPg
     ports:
-      - 8432:5432
+      - "8432:5432"
 
   pgadmin:
 #    https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html
@@ -48,7 +48,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: user@domain.com
       PGADMIN_DEFAULT_PASSWORD: SuperSecret
     ports:
-      - 8081:80
+      - "8081:80"
 
   conjur:
     image: cyberark/conjur
@@ -63,7 +63,7 @@ services:
     - database
     restart: on-failure
     ports:
-      - 8080:80
+      - "8080:80"
 
   proxy:
     image: nginx:latest


### PR DESCRIPTION
When testing, conjur_server would fail to start when running 'sudo docker compose up -d'.

After reviewing this docker-compose file, it was observed the 'port' variable on line 72 was double-quoted. 

After adding the quotes on line 66, conjur_server was able to be start successfully.

Added quotes to line 42, line 51, line 66 to conform to standard

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
